### PR TITLE
Thread safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .rvmrc
 .bundle
+.ruby-version
 pkg
 rdoc

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 group :development, :test do
   gem 'rake'
   gem 'rdoc'
+  gem 'minitest'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,6 @@ PLATFORMS
 DEPENDENCIES
   fakeweb (~> 1.3.0)
   geckoboard-push!
-  httparty (~> 0.8.1)
   mocha (~> 0.10.0)
   rake
   rdoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ GEM
       multi_json
       multi_xml
     json (1.7.3)
-    metaclass (0.0.1)
-    mocha (0.10.0)
+    metaclass (0.0.4)
+    mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.0.4)
     multi_xml (0.4.1)
@@ -27,6 +27,6 @@ PLATFORMS
 DEPENDENCIES
   fakeweb (~> 1.3.0)
   geckoboard-push!
-  mocha (~> 0.10.0)
+  mocha (~> 1.1.0)
   rake
   rdoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,9 @@ GEM
     httparty (0.8.1)
       multi_json
       multi_xml
-    json (1.7.3)
+    json (1.8.6)
     metaclass (0.0.4)
+    minitest (5.14.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.0.4)
@@ -27,6 +28,10 @@ PLATFORMS
 DEPENDENCIES
   fakeweb (~> 1.3.0)
   geckoboard-push!
+  minitest
   mocha (~> 1.1.0)
   rake
   rdoc
+
+BUNDLED WITH
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "rdoc/task"
 
 require "rake/testtask"
 Rake::TestTask.new do |t|
-  t.libs << "test"
+  t.libs << "minitest"
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
 end
@@ -30,7 +30,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency "httparty", "~> 0.8.1"
 
   s.add_development_dependency "fakeweb", "~> 1.3.0"
-  s.add_development_dependency "mocha", "~> 0.10.0"
+  s.add_development_dependency "mocha", "~> 1.1.0"
 end
 
 Gem::PackageTask.new(spec) do |pkg|

--- a/geckoboard-push.gemspec
+++ b/geckoboard-push.gemspec
@@ -23,15 +23,15 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<httparty>, ["~> 0.8.1"])
       s.add_development_dependency(%q<fakeweb>, ["~> 1.3.0"])
-      s.add_development_dependency(%q<mocha>, ["~> 0.10.0"])
+      s.add_development_dependency(%q<mocha>, ["~> 1.1.0"])
     else
       s.add_dependency(%q<httparty>, ["~> 0.8.1"])
       s.add_dependency(%q<fakeweb>, ["~> 1.3.0"])
-      s.add_dependency(%q<mocha>, ["~> 0.10.0"])
+      s.add_dependency(%q<mocha>, ["~> 1.1.0"])
     end
   else
     s.add_dependency(%q<httparty>, ["~> 0.8.1"])
     s.add_dependency(%q<fakeweb>, ["~> 1.3.0"])
-    s.add_dependency(%q<mocha>, ["~> 0.10.0"])
+    s.add_dependency(%q<mocha>, ["~> 1.1.0"])
   end
 end

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -23,7 +23,7 @@ module Geckoboard
     # Makes a call to Geckoboard to push data to the current widget
     def push(data)
       raise Geckoboard::Push::Error.new("Api key not configured.") if @api_key.nil? || @api_key.empty?
-      result = JSON.parse(self.class.post("/#{@api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => @api_key, :data => data}.to_json}))
+      result = JSON.parse(self.class.post("/#{@api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => @api_key, :data => data}.to_json}).body)
       raise Geckoboard::Push::Error.new(result["error"]) unless result["success"]
       result["success"]
     end

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -23,7 +23,7 @@ module Geckoboard
     # Makes a call to Geckoboard to push data to the current widget
     def push(data)
       raise Geckoboard::Push::Error.new("Api key not configured.") if @api_key.nil? || @api_key.empty?
-      result = JSON.parse(self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => @api_key, :data => data}.to_json}))
+      result = JSON.parse(self.class.post("/#{@api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => @api_key, :data => data}.to_json}))
       raise Geckoboard::Push::Error.new(result["error"]) unless result["success"]
       result["success"]
     end

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -24,7 +24,7 @@ module Geckoboard
     def push(data)
       raise Geckoboard::Push::Error.new("Api key not configured.") if @api_key.nil? || @api_key.empty?
       result = JSON.parse(self.class.post("/#{@api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => @api_key, :data => data}.to_json}).body)
-      raise Geckoboard::Push::Error.new(result["error"]) unless result["success"]
+      raise Geckoboard::Push::Error.new(result["error"] || result["message"]) unless result["success"]
       result["success"]
     end
 

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -4,11 +4,9 @@ require 'json'
 
 module Geckoboard
   class Push
-    class << self
-      # API configuration
-      attr_accessor :api_key
-      attr_accessor :api_version
-    end
+    # API configuration
+    attr_accessor :api_key
+    attr_accessor :api_version
 
     # Custom error type for handling API errors
     class Error < Exception; end
@@ -17,14 +15,15 @@ module Geckoboard
     base_uri 'https://push.geckoboard.com'
 
     # Initializes the push object for a specific widget
-    def initialize(widget_key)
+    def initialize(api_key, widget_key)
+      @api_key = api_key
       @widget_key = widget_key
     end
 
     # Makes a call to Geckoboard to push data to the current widget
     def push(data)
-      raise Geckoboard::Push::Error.new("Api key not configured.") if Geckoboard::Push.api_key.nil? || Geckoboard::Push.api_key.empty?
-      result = JSON.parse(self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => Geckoboard::Push.api_key, :data => data}.to_json}))
+      raise Geckoboard::Push::Error.new("Api key not configured.") if @api_key.nil? || @api_key.empty?
+      result = JSON.parse(self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => @api_key, :data => data}.to_json}))
       raise Geckoboard::Push::Error.new(result["error"]) unless result["success"]
       result["success"]
     end

--- a/test/geckoboard/push_test.rb
+++ b/test/geckoboard/push_test.rb
@@ -2,67 +2,65 @@ require 'test/unit'
 gem 'fakeweb'
 require 'fakeweb'
 gem 'mocha'
-require 'mocha'
+require 'mocha/setup'
 require File.join(File.expand_path(File.dirname(__FILE__)), "..", "..", "lib", "geckoboard", "push")
 
 class PushTest < Test::Unit::TestCase
   def setup
     FakeWeb.allow_net_connect = false
-    Geckoboard::Push.api_key = "12345"
-    @push = Geckoboard::Push.new("54321")
+    @api_key = "12345"
+    @widget_key = "54321"
   end
 
   def test_with_no_api_key
-    Geckoboard::Push.api_key = nil
     assert_raise Geckoboard::Push::Error do
-      @push.number_and_secondary_value(100, 10)
+      Geckoboard::Push.new(nil, @widget_key).number_and_secondary_value(100, 10)
     end
   end
 
   def test_invalid_key
-    Geckoboard::Push.api_key = "invalid"
     response = Net::HTTPOK.new("1.1", 200, "OK")
     response.instance_variable_set(:@body, '{"success":false,"error":"Api key has wrong format. "}')
     response.instance_variable_set(:@read, true)
     Net::HTTP.any_instance.expects(:request).returns(response)
     assert_raise Geckoboard::Push::Error do
-      @push.number_and_secondary_value(100, 10)
+      Geckoboard::Push.new("invalid", @widget_key).number_and_secondary_value(100, 10)
     end
   end
 
   def test_number_and_secondary_value
     expect_http_request({"api_key" => "12345", "data" => {"item" => [{"text" => "", "value" => 100}, {"text" => "", "value" => 10}]}}.to_json)
-    assert_equal true, @push.number_and_secondary_value(100, 10)
+    assert_equal true, Geckoboard::Push.new(@api_key, @widget_key).number_and_secondary_value(100, 10)
   end
 
   def test_text
     expect_http_request({"api_key" => "12345", "data" => {"item" => [{"text" => "Test1", "type" => 2}, {"text" => "Test2", "type" => 1}]}}.to_json)
-    assert_equal true, @push.text([{:type => :info, :text => "Test1"}, {:type => :alert, :text => "Test2"}])
+    assert_equal true, Geckoboard::Push.new(@api_key, @widget_key).text([{:type => :info, :text => "Test1"}, {:type => :alert, :text => "Test2"}])
   end
 
   def test_rag
     expect_http_request({"api_key" => "12345", "data" => {"item" => [{"value" => 1}, {"value" => 2}, {"value" => 3}]}}.to_json)
-    assert_equal true, @push.rag(1,2,3)
+    assert_equal true, Geckoboard::Push.new(@api_key, @widget_key).rag(1,2,3)
   end
 
   def test_line
     expect_http_request({"api_key" => "12345", "data" => {"item" => [1,2,3], "settings" => {"axisx" => "x axis", "axisy" => "y axis", "colour" => "ff9900"}}}.to_json)
-    assert_equal true, @push.line([1,2,3], "ff9900", "x axis", "y axis")
+    assert_equal true, Geckoboard::Push.new(@api_key, @widget_key).line([1,2,3], "ff9900", "x axis", "y axis")
   end
 
   def test_pie
     expect_http_request({"api_key" => "12345", "data" => {"item" => [{"value" => 1, "label" => "Test1", "colour" => "ff9900"}, {"value" => 2, "label" => "Test2", "colour" => "ff0099"}]}}.to_json)
-    assert_equal true, @push.pie([{:value => 1, :label => "Test1", :colour => "ff9900"}, {:value => 2, :label => "Test2", :colour => "ff0099"}])
+    assert_equal true, Geckoboard::Push.new(@api_key, @widget_key).pie([{:value => 1, :label => "Test1", :colour => "ff9900"}, {:value => 2, :label => "Test2", :colour => "ff0099"}])
   end
 
   def test_geckometer
     expect_http_request({"api_key" => "12345", "data" => {"item" => 100, "min" => {"value" => 50}, "max" => {"value" => 200}}}.to_json)
-    assert_equal true, @push.geckometer(100, 50, 200)
+    assert_equal true, Geckoboard::Push.new(@api_key, @widget_key).geckometer(100, 50, 200)
   end
 
   def test_funnel
     expect_http_request({"api_key" => "12345", "data" => {"item" => [{"value" => 5, "label" => "Test1"}, {"value" => 10, "label" => "Test2"}], "type" => "reverse", "percentage" => "hide"}}.to_json)
-    assert_equal true, @push.funnel([{:label => "Test1", :value => 5}, {:label => "Test2", :value => 10}], true, true)
+    assert_equal true, Geckoboard::Push.new(@api_key, @widget_key).funnel([{:label => "Test1", :value => 5}, {:label => "Test2", :value => 10}], true, true)
   end
 
   def expect_http_request(json)

--- a/test/geckoboard/push_test.rb
+++ b/test/geckoboard/push_test.rb
@@ -1,11 +1,12 @@
-require 'test/unit'
+require 'minitest/autorun'
 gem 'fakeweb'
 require 'fakeweb'
 gem 'mocha'
-require 'mocha/setup'
+require 'minitest/unit'
+require 'mocha/mini_test'
 require File.join(File.expand_path(File.dirname(__FILE__)), "..", "..", "lib", "geckoboard", "push")
 
-class PushTest < Test::Unit::TestCase
+class PushTest < MiniTest::Unit::TestCase
   def setup
     FakeWeb.allow_net_connect = false
     @api_key = "12345"
@@ -13,7 +14,7 @@ class PushTest < Test::Unit::TestCase
   end
 
   def test_with_no_api_key
-    assert_raise Geckoboard::Push::Error do
+    assert_raises Geckoboard::Push::Error do
       Geckoboard::Push.new(nil, @widget_key).number_and_secondary_value(100, 10)
     end
   end
@@ -23,7 +24,7 @@ class PushTest < Test::Unit::TestCase
     response.instance_variable_set(:@body, '{"success":false,"error":"Api key has wrong format. "}')
     response.instance_variable_set(:@read, true)
     Net::HTTP.any_instance.expects(:request).returns(response)
-    assert_raise Geckoboard::Push::Error do
+    assert_raises Geckoboard::Push::Error do
       Geckoboard::Push.new("invalid", @widget_key).number_and_secondary_value(100, 10)
     end
   end

--- a/test/geckoboard/push_test.rb
+++ b/test/geckoboard/push_test.rb
@@ -21,10 +21,20 @@ class PushTest < MiniTest::Unit::TestCase
 
   def test_invalid_key
     response = Net::HTTPOK.new("1.1", 200, "OK")
-    response.instance_variable_set(:@body, '{"success":false,"error":"Api key has wrong format. "}')
+    response.instance_variable_set(:@body, '{"success":false,"error":"Api key has wrong format."}')
     response.instance_variable_set(:@read, true)
     Net::HTTP.any_instance.expects(:request).returns(response)
-    assert_raises Geckoboard::Push::Error do
+    assert_raises(Geckoboard::Push::Error, "Api key has wrong format.") do
+      Geckoboard::Push.new("invalid", @widget_key).number_and_secondary_value(100, 10)
+    end
+  end
+
+  def test_invalid_api_key_with_new_error_location
+    response = Net::HTTPOK.new("1.1", 401, "Unauthorized")
+    response.instance_variable_set(:@body, '{"message":"Your API key is invalid"}')
+    response.instance_variable_set(:@read, true)
+    Net::HTTP.any_instance.expects(:request).returns(response)
+    assert_raises(Geckoboard::Push::Error, "Your API key is invalid") do
       Geckoboard::Push.new("invalid", @widget_key).number_and_secondary_value(100, 10)
     end
   end


### PR DESCRIPTION
Since I'm running geckoboard-push updates in sidekiq (which uses threads), I needed geckoboard-push to be thread-safe, which it obviously wasn't before (it was storing the api_key in a class variable). In my app, each Geckoboard push uses a different API key (the app user's key, not mine), so there would be a potential race condition.

This was a simple change. I basically just changed api_key and api_version to be instance variables, and updates tests accordingly.
