### PR TITLE
Don't lock httparty and fakeweb to ancient versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,30 @@ PATH
   remote: .
   specs:
     geckoboard-push (0.1.0)
-      httparty (~> 0.8.1)
+      httparty
 
 GEM
   remote: http://rubygems.org/
   specs:
     fakeweb (1.3.0)
-    httparty (0.8.1)
-      multi_json
-      multi_xml
-    json (1.7.3)
-    metaclass (0.0.1)
-    mocha (0.10.0)
+    httparty (0.13.0)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    json (1.8.1)
+    metaclass (0.0.4)
+    mocha (1.0.0)
       metaclass (~> 0.0.1)
-    multi_json (1.0.4)
-    multi_xml (0.4.1)
-    rake (0.9.2.2)
-    rdoc (3.12)
+    multi_xml (0.5.5)
+    rake (10.1.1)
+    rdoc (4.1.1)
       json (~> 1.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  fakeweb (~> 1.3.0)
+  fakeweb
   geckoboard-push!
-  httparty (~> 0.8.1)
-  mocha (~> 0.10.0)
+  mocha
   rake
   rdoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       multi_xml (>= 0.5.2)
     json (1.8.1)
     metaclass (0.0.4)
-    mocha (1.0.0)
+    mocha (0.10.0)
       metaclass (~> 0.0.1)
     multi_xml (0.5.5)
     rake (10.1.1)
@@ -26,6 +26,6 @@ PLATFORMS
 DEPENDENCIES
   fakeweb
   geckoboard-push!
-  mocha
+  mocha (~> 0.10.0)
   rake
   rdoc

--- a/geckoboard-push.gemspec
+++ b/geckoboard-push.gemspec
@@ -21,17 +21,17 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<httparty>, ["~> 0.8.1"])
-      s.add_development_dependency(%q<fakeweb>, ["~> 1.3.0"])
-      s.add_development_dependency(%q<mocha>, ["~> 0.10.0"])
+      s.add_runtime_dependency(%q<httparty>)
+      s.add_development_dependency(%q<fakeweb>)
+      s.add_development_dependency(%q<mocha>)
     else
-      s.add_dependency(%q<httparty>, ["~> 0.8.1"])
-      s.add_dependency(%q<fakeweb>, ["~> 1.3.0"])
-      s.add_dependency(%q<mocha>, ["~> 0.10.0"])
+      s.add_dependency(%q<httparty>)
+      s.add_dependency(%q<fakeweb>)
+      s.add_dependency(%q<mocha>)
     end
   else
-    s.add_dependency(%q<httparty>, ["~> 0.8.1"])
-    s.add_dependency(%q<fakeweb>, ["~> 1.3.0"])
-    s.add_dependency(%q<mocha>, ["~> 0.10.0"])
+    s.add_dependency(%q<httparty>)
+    s.add_dependency(%q<fakeweb>)
+    s.add_dependency(%q<mocha>)
   end
 end

--- a/geckoboard-push.gemspec
+++ b/geckoboard-push.gemspec
@@ -23,15 +23,15 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<httparty>)
       s.add_development_dependency(%q<fakeweb>)
-      s.add_development_dependency(%q<mocha>)
+      s.add_development_dependency(%q<mocha>, ["~> 0.10.0"])
     else
       s.add_dependency(%q<httparty>)
       s.add_dependency(%q<fakeweb>)
-      s.add_dependency(%q<mocha>)
+      s.add_dependency(%q<mocha>, ["~> 0.10.0"])
     end
   else
     s.add_dependency(%q<httparty>)
     s.add_dependency(%q<fakeweb>)
-    s.add_dependency(%q<mocha>)
+    s.add_dependency(%q<mocha>, ["~> 0.10.0"])
   end
 end


### PR DESCRIPTION
Otherwise, we'll have conflicts with modern Gems that need more recent versions.
