### PR TITLE
Add support for leaderboard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,6 @@ PLATFORMS
 DEPENDENCIES
   fakeweb (~> 1.3.0)
   geckoboard-push!
-  httparty (~> 0.8.1)
   mocha (~> 0.10.0)
   rake
   rdoc

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -93,5 +93,19 @@ module Geckoboard
       opts[:percentage] = "hide" if hide_percentage
       self.push(opts)
     end
+
+    # Items should be an array of hashes, each hash containing:
+    # - value (numeric value)
+    # - label (optional)
+    # - previous_rank (optional)
+    def leaderboard(items)
+      data = items.collect do |item|
+        d = {:value => item[:value], :label => item[:label]}
+        d[:previous_rank] = item[:previous_rank] if item.include?(:previous_rank)
+        d
+      end
+      opts = {:items => data}
+      self.push(opts)
+    end
   end
 end

--- a/lib/geckoboard/push.rb
+++ b/lib/geckoboard/push.rb
@@ -24,7 +24,7 @@ module Geckoboard
     # Makes a call to Geckoboard to push data to the current widget
     def push(data)
       raise Geckoboard::Push::Error.new("Api key not configured.") if Geckoboard::Push.api_key.nil? || Geckoboard::Push.api_key.empty?
-      result = JSON.parse(self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => Geckoboard::Push.api_key, :data => data}.to_json}))
+      result = JSON.parse(self.class.post("/#{Geckoboard::Push.api_version || 'v1'}/send/#{@widget_key}", {:body => {:api_key => Geckoboard::Push.api_key, :data => data}.to_json}).body)
       raise Geckoboard::Push::Error.new(result["error"]) unless result["success"]
       result["success"]
     end

--- a/test/geckoboard/push_test.rb
+++ b/test/geckoboard/push_test.rb
@@ -66,7 +66,7 @@ class PushTest < Test::Unit::TestCase
   end
 
   def test_leaderboard
-    expect_http_request({"api_key" => "12345", "data" => {"item" => [{"value" => 5, "label" => "Test1"}, {"value" => 10, "label" => "Test2", "previous_rank" => "2"}]}}.to_json)
+    expect_http_request({"api_key" => "12345", "data" => {"items" => [{"value" => 5, "label" => "Test1"}, {"value" => 10, "label" => "Test2", "previous_rank" => "2"}]}}.to_json)
     assert_equal true, @push.leaderboard([{:label => "Test1", :value => 5}, {:label => "Test2", :value => 10, :previous_rank => 2}])
   end
 

--- a/test/geckoboard/push_test.rb
+++ b/test/geckoboard/push_test.rb
@@ -65,6 +65,11 @@ class PushTest < Test::Unit::TestCase
     assert_equal true, @push.funnel([{:label => "Test1", :value => 5}, {:label => "Test2", :value => 10}], true, true)
   end
 
+  def test_leaderboard
+    expect_http_request({"api_key" => "12345", "data" => {"item" => [{"value" => 5, "label" => "Test1"}, {"value" => 10, "label" => "Test2", "previous_rank" => "2"}]}}.to_json)
+    assert_equal true, @push.leaderboard([{:label => "Test1", :value => 5}, {:label => "Test2", :value => 10, :previous_rank => 2}])
+  end
+
   def expect_http_request(json)
     response = Net::HTTPOK.new("1.1", 200, "OK")
     response.instance_variable_set(:@body, '{"success":true}')


### PR DESCRIPTION
- Added HTTParty::Response fix from #6
- Add support for [Leaderboard](https://developer.geckoboard.com/#leaderboard)
